### PR TITLE
[codex] Add English documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 面向中文读者重新整理的 Go 开源项目目录。新版目录不再追求“尽可能全”，而是优先保留仍在维护、社区认知清晰、适合学习和选型的项目，并补充了 AI Agent 相关项目。
 
-当前版本收录 **75** 个项目，分成 **10** 个主题；最近一次维护状态审阅时间为 **2026-03-06**。
+当前版本收录 **77** 个项目，分成 **10** 个主题；最近一次维护状态审阅时间为 **2026-03-06**。
 
+- [English version](README_EN.md)
 - [分类与维护策略](docs/分类与维护策略.md)
 - [移除与迁移记录](docs/移除与迁移记录.md)
 
@@ -25,11 +26,11 @@
 
 | 分类 | 关注点 | 项目数 |
 | --- | --- | --- |
-| AI / Agent | LLM 应用框架、MCP、模型运行时与向量能力 | 7 |
+| AI / Agent | LLM 应用框架、MCP、模型运行时与向量能力 | 8 |
 | 云原生与容器 | 容器运行时、编排、镜像仓库和集群平台 | 8 |
 | 服务治理与平台工程 | PaaS、服务治理、CI/CD、消息与异步任务 | 12 |
 | 数据存储与搜索 | 数据库、分布式存储、检索与数据访问生态 | 10 |
-| 可观测性 | 指标、图表、告警与运行状态检查 | 5 |
+| 可观测性 | 指标、图表、告警与运行状态检查 | 6 |
 | 网络与安全 | 网关、负载均衡、代理、流量调试与网络工具 | 6 |
 | Web 开发与应用 | Web 框架、服务端组件与实时交互能力 | 11 |
 | 数据处理与机器学习 | ML、NLP、爬虫与数据处理 | 6 |
@@ -49,8 +50,7 @@ LLM 应用框架、MCP、模型运行时与向量能力
 | [mudler/LocalAI](https://github.com/mudler/LocalAI) | OpenAI 兼容的本地推理服务，适合私有化部署。 |
 | [mudler/LocalAGI](https://github.com/mudler/LocalAGI) | 面向本地模型的 Agent 平台，强调工具调用和自治流程。 |
 | [weaviate/weaviate](https://github.com/weaviate/weaviate) | Go 编写的向量数据库，可用于 RAG、检索和 Agent memory。 |
-| [pardnchiu/Agenvoy](https://github.com/pardnchiu/Agenvoy) | Go 编写的 Agent 平台，提供 Py/Js 工具接口，与错误记忆与自动修正 |
-
+| [pardnchiu/Agenvoy](https://github.com/pardnchiu/Agenvoy) | Go 编写的 Agent 平台，提供 Py/Js 工具接口、错误记忆与自动修正能力。 |
 
 ## 云原生与容器
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,189 @@
+# Golang Open Source Projects
+
+A curated Go open source project catalog for English readers. This refreshed list no longer tries to be exhaustive; it prioritizes projects that are still maintained, have clear community recognition, and are useful for learning or technology selection, with additional coverage for AI Agent projects.
+
+Current version includes **77** projects across **10** topics; the latest maintenance status review was completed on **2026-03-06**.
+
+- [Chinese version](README.md)
+- [Category and maintenance policy](docs/category-and-maintenance-policy.md)
+- [Removal and migration log](docs/removal-and-migration-log.md)
+
+## What Changed in This Refresh
+
+- Reorganized the old 17 loose categories into 10 topic areas and removed the hard-to-maintain "Other" category.
+- Removed archived, abandoned, or long-inactive repositories that now have clearer alternatives.
+- Removed duplicate entries so each project appears in the most appropriate category only once.
+- Added an AI / Agent category covering LLM application frameworks, MCP, inference runtimes, and vector search.
+
+## Selection Principles
+
+- Prefer projects that could still be confirmed as maintained as of 2026-03-06.
+- Archived repositories, missing repositories, and long-inactive projects with better alternatives are removed by default.
+- Emphasize learning value and practical engineering selection value instead of keeping many edge projects only for coverage.
+- Include each project only once to avoid duplication across categories.
+
+## Category Navigation
+
+| Category | Focus | Projects |
+| --- | --- | --- |
+| AI / Agent | LLM application frameworks, MCP, model runtimes, and vector capabilities | 8 |
+| Cloud Native and Containers | Container runtimes, orchestration, registries, and cluster platforms | 8 |
+| Service Governance and Platform Engineering | PaaS, service governance, CI/CD, messaging, and async jobs | 12 |
+| Data Storage and Search | Databases, distributed storage, search, and data access ecosystems | 10 |
+| Observability | Metrics, dashboards, alerting, and runtime health checks | 6 |
+| Networking and Security | Gateways, load balancing, proxies, traffic debugging, and network tools | 6 |
+| Web Development and Applications | Web frameworks, server-side components, and realtime interaction | 11 |
+| Data Processing and Machine Learning | ML, NLP, crawlers, and data processing | 6 |
+| Developer Tools and Core Libraries | Developer productivity, testing, terminal UI, and core libraries | 8 |
+| Blockchain | Maintained and highly influential Go blockchain projects | 2 |
+
+## AI / Agent
+
+LLM application frameworks, MCP, model runtimes, and vector capabilities
+
+| Project | Description |
+| --- | --- |
+| [ollama/ollama](https://github.com/ollama/ollama) | A Go runtime for running, distributing, and managing large language models locally. |
+| [tmc/langchaingo](https://github.com/tmc/langchaingo) | An LLM application framework for Go, covering prompts, tool calling, agents, and RAG. |
+| [cloudwego/eino](https://github.com/cloudwego/eino) | A Go AI application framework from CloudWeGo focused on component orchestration and production use. |
+| [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) | A practical SDK for building MCP clients and servers in Go. |
+| [mudler/LocalAI](https://github.com/mudler/LocalAI) | An OpenAI-compatible local inference server suitable for private deployments. |
+| [mudler/LocalAGI](https://github.com/mudler/LocalAGI) | An agent platform for local models with an emphasis on tool calling and autonomous workflows. |
+| [weaviate/weaviate](https://github.com/weaviate/weaviate) | A vector database written in Go for RAG, retrieval, and agent memory. |
+| [pardnchiu/Agenvoy](https://github.com/pardnchiu/Agenvoy) | An agent platform written in Go with Python/JavaScript tool interfaces, error memory, and automatic correction. |
+
+## Cloud Native and Containers
+
+Container runtimes, orchestration, registries, and cluster platforms
+
+| Project | Description |
+| --- | --- |
+| [moby/moby](https://github.com/moby/moby) | The upstream project for the Docker engine and a core entry point for studying container runtime implementation. |
+| [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) | The de facto standard container orchestration platform. |
+| [goharbor/harbor](https://github.com/goharbor/harbor) | An enterprise OCI registry with access control, auditing, and replication features. |
+| [rancher/rancher](https://github.com/rancher/rancher) | A Kubernetes management platform for multi-cluster scenarios. |
+| [quay/clair](https://github.com/quay/clair) | A container image vulnerability analysis and scanning service. |
+| [moby/swarmkit](https://github.com/moby/swarmkit) | The core orchestration component behind Docker Swarm, useful for studying scheduling and cluster orchestration. |
+| [AliyunContainerService/pouch](https://github.com/AliyunContainerService/pouch) | Alibaba's open source container engine focused on stronger isolation and stability. |
+| [hashicorp/nomad](https://github.com/hashicorp/nomad) | A lightweight workload orchestrator and a useful alternative path to compare with Kubernetes. |
+
+## Service Governance and Platform Engineering
+
+PaaS, service governance, CI/CD, messaging, and async jobs
+
+| Project | Description |
+| --- | --- |
+| [tsuru/tsuru](https://github.com/tsuru/tsuru) | A mature open source PaaS for learning application platform abstractions. |
+| [goodrain/rainbond](https://github.com/goodrain/rainbond) | An application-centric cloud native platform covering delivery, operations, and microservice governance. |
+| [harness/harness](https://github.com/harness/harness) | The current CI/CD and developer platform entry point after Drone became part of the Harness ecosystem. |
+| [gravitational/teleport](https://github.com/gravitational/teleport) | A zero-trust remote access and infrastructure access platform. |
+| [istio/istio](https://github.com/istio/istio) | A representative service mesh project covering traffic management, security, and observability. |
+| [uber/jaeger](https://github.com/uber/jaeger) | A distributed tracing system, useful for understanding tracing together with OpenTelemetry. |
+| [go-kit/kit](https://github.com/go-kit/kit) | A Go microservices toolkit emphasizing observability and testability. |
+| [goadesign/goa](https://github.com/goadesign/goa) | A design-first framework for developing Go services. |
+| [TykTechnologies/tyk](https://github.com/TykTechnologies/tyk) | A mature open source API gateway. |
+| [micro/go-micro](https://github.com/micro/go-micro) | A Go microservices framework useful for studying service abstractions and plugin-based extension. |
+| [nsqio/nsq](https://github.com/nsqio/nsq) | A classic realtime distributed messaging platform. |
+| [RichardKnop/machinery](https://github.com/RichardKnop/machinery) | An async task queue for Go and a useful reference for Celery-like designs. |
+
+## Data Storage and Search
+
+Databases, distributed storage, search, and data access ecosystems
+
+| Project | Description |
+| --- | --- |
+| [cockroachdb/cockroach](https://github.com/cockroachdb/cockroach) | A distributed SQL database focused on strong consistency and elastic scaling. |
+| [vitessio/vitess](https://github.com/vitessio/vitess) | YouTube's open source solution for horizontally scaling MySQL. |
+| [pingcap/tidb](https://github.com/pingcap/tidb) | A distributed HTAP database compatible with the MySQL protocol. |
+| [influxdata/influxdb](https://github.com/influxdata/influxdb) | A classic time series database project. |
+| [dgraph-io/dgraph](https://github.com/dgraph-io/dgraph) | A distributed graph database for relationship-heavy query scenarios. |
+| [ipfs/kubo](https://github.com/ipfs/kubo) | The Go implementation of IPFS. |
+| [chrislusf/seaweedfs](https://github.com/chrislusf/seaweedfs) | A high-performance distributed file system covering object, file, and block storage. |
+| [XiaoMi/Gaea](https://github.com/XiaoMi/Gaea) | Xiaomi's open source MySQL middleware focused on sharding and proxy capabilities. |
+| [mediocregopher/radix](https://github.com/mediocregopher/radix) | A cleanly designed Go Redis client. |
+| [olivere/elastic](https://github.com/olivere/elastic) | A long-standing and widely used Elasticsearch client in the Go ecosystem. |
+
+## Observability
+
+Metrics, dashboards, alerting, and runtime health checks
+
+| Project | Description |
+| --- | --- |
+| [grafana/grafana](https://github.com/grafana/grafana) | One of the most common observability visualization platforms. |
+| [prometheus/prometheus](https://github.com/prometheus/prometheus) | The de facto standard monitoring and time series metrics system. |
+| [influxdata/kapacitor](https://github.com/influxdata/kapacitor) | InfluxData's realtime processing, alerting, and monitoring component. |
+| [sourcegraph/checkup](https://github.com/sourcegraph/checkup) | A distributed health-checking tool for probing site and service availability. |
+| [rapidloop/rtop](https://github.com/rapidloop/rtop) | A lightweight SSH-based remote server monitoring tool. |
+| [kubestellar/console](https://github.com/kubestellar/console) | An AI-powered multi-cluster Kubernetes dashboard with realtime observability and 30+ CNCF project integrations. A CNCF Sandbox project. |
+
+## Networking and Security
+
+Gateways, load balancing, proxies, traffic debugging, and network tools
+
+| Project | Description |
+| --- | --- |
+| [traefik/traefik](https://github.com/traefik/traefik) | A widely used cloud native reverse proxy and load balancer. |
+| [google/seesaw](https://github.com/google/seesaw) | Google's open source Linux load balancing system. |
+| [jpillora/go-tcp-proxy](https://github.com/jpillora/go-tcp-proxy) | A simple implementation that is especially useful for learning TCP proxy fundamentals. |
+| [probelabs/goreplay](https://github.com/probelabs/goreplay) | A classic tool for replaying production HTTP traffic into test environments. |
+| [hidu/pproxy](https://github.com/hidu/pproxy) | An HTTP capture proxy and debugging tool. |
+| [getlantern/lantern](https://github.com/getlantern/lantern) | A long-maintained network proxy project and a reference for cross-platform network client design. |
+
+## Web Development and Applications
+
+Web frameworks, server-side components, and realtime interaction
+
+| Project | Description |
+| --- | --- |
+| [gin-gonic/gin](https://github.com/gin-gonic/gin) | One of the most common high-performance choices among Go web frameworks. |
+| [labstack/echo](https://github.com/labstack/echo) | A mature high-performance web framework with a strong API development experience. |
+| [beego/beego](https://github.com/beego/beego) | A long-standing full-featured Go web framework that is still maintained. |
+| [revel/revel](https://github.com/revel/revel) | A Go web framework with a more full-stack approach. |
+| [kataras/iris](https://github.com/kataras/iris) | A web framework emphasizing performance and a complete ecosystem. |
+| [go-macaron/macaron](https://github.com/go-macaron/macaron) | A Go web framework with a clear modular style. |
+| [andeya/faygo](https://github.com/andeya/faygo) | A Go web framework for API scenarios, with parameter binding and documentation generation. |
+| [olahol/melody](https://github.com/olahol/melody) | A lightweight WebSocket framework based on gorilla/websocket. |
+| [valyala/fasthttp](https://github.com/valyala/fasthttp) | A highly representative high-performance HTTP implementation in Go. |
+| [tus/tusd](https://github.com/tus/tusd) | A server implementation for resumable file uploads. |
+| [mattermost/mattermost](https://github.com/mattermost/mattermost) | A representative large Go web application and a good reference for real-world business system organization. |
+
+## Data Processing and Machine Learning
+
+ML, NLP, crawlers, and data processing
+
+| Project | Description |
+| --- | --- |
+| [gorgonia/gorgonia](https://github.com/gorgonia/gorgonia) | One of the most representative deep learning and tensor computation projects in the Go ecosystem. |
+| [cdipaolo/goml](https://github.com/cdipaolo/goml) | Provides implementations for online learning, clustering, regression, and related algorithms. |
+| [sjwhitworth/golearn](https://github.com/sjwhitworth/golearn) | A Go library focused more on traditional machine learning workflows. |
+| [andeya/pholcus](https://github.com/andeya/pholcus) | A distributed crawler framework written in Go. |
+| [yanyiwu/gojieba](https://github.com/yanyiwu/gojieba) | A Go version of the Jieba Chinese word segmentation library. |
+| [chrislusf/gleam](https://github.com/chrislusf/gleam) | A Go-style data processing and distributed computing framework. |
+
+## Developer Tools and Core Libraries
+
+Developer productivity, testing, terminal UI, and core libraries
+
+| Project | Description |
+| --- | --- |
+| [gohugoio/hugo](https://github.com/gohugoio/hugo) | The most representative Go static site generator. |
+| [grpc/grpc-go](https://github.com/grpc/grpc-go) | The official Go implementation of gRPC. |
+| [rakyll/hey](https://github.com/rakyll/hey) | A lightweight load testing tool. |
+| [visualfc/liteide](https://github.com/visualfc/liteide) | A cross-platform Go IDE. |
+| [mailslurper/mailslurper](https://github.com/mailslurper/mailslurper) | A very practical test SMTP server for local development. |
+| [gizak/termui](https://github.com/gizak/termui) | A Go UI library for building visual dashboards in the terminal. |
+| [golang/mobile](https://github.com/golang/mobile) | The official Go mobile development toolchain. |
+| [hound-search/hound](https://github.com/hound-search/hound) | A code search tool suitable for self-hosting. |
+
+## Blockchain
+
+Maintained and highly influential Go blockchain projects
+
+| Project | Description |
+| --- | --- |
+| [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum) | The official implementation of geth, the Ethereum client. |
+| [hyperledger/fabric](https://github.com/hyperledger/fabric) | A representative enterprise permissioned blockchain platform. |
+
+## Maintenance Notes
+
+This catalog has removed duplicate entries, outdated repositories, and the old catch-all "Other" category from the previous README. For future expansion, update [projects.json](projects.json) first, run `go run ./tools/generate_readme.go` to refresh the Chinese README, and then update this English README to keep both versions aligned.

--- a/docs/category-and-maintenance-policy.md
+++ b/docs/category-and-maintenance-policy.md
@@ -1,0 +1,48 @@
+# Category and Maintenance Policy
+
+[Chinese version](分类与维护策略.md)
+
+## Goals of This Refactor
+
+The old catalog had four main issues:
+
+- Category granularity was inconsistent, and the boundaries between `Web Tools`, `Web Frameworks`, and `Other` were unclear.
+- The same project could appear in multiple categories, which made lookup harder.
+- The catalog mixed together "still worth recommending" and "historically appeared in the Go ecosystem".
+- AI / Agent projects were barely covered, which no longer reflects current areas of interest in the Go ecosystem.
+
+This refresh narrows the catalog into 10 topic categories and limits each project to a single entry.
+
+## New Categories
+
+| Category | Focus |
+| --- | --- |
+| AI / Agent | LLM application frameworks, MCP, model runtimes, vector search |
+| Cloud Native and Containers | Container runtimes, orchestration, registries, cluster platforms |
+| Service Governance and Platform Engineering | PaaS, service governance, CI/CD, messaging, async jobs |
+| Data Storage and Search | Databases, distributed storage, search, data access ecosystems |
+| Observability | Metrics, dashboards, alerting, health checks |
+| Networking and Security | Gateways, proxies, load balancing, traffic debugging |
+| Web Development and Applications | Web frameworks, WebSocket, HTTP components |
+| Data Processing and Machine Learning | ML, NLP, crawlers, data processing |
+| Developer Tools and Core Libraries | Core libraries, testing tools, terminal UI, IDEs |
+| Blockchain | Maintained and sufficiently influential Go blockchain projects |
+
+## Selection Criteria
+
+Maintenance status review date: `2026-03-06`
+
+- Prefer projects that could still be confirmed as maintained.
+- Remove archived repositories directly.
+- Remove long-inactive projects by default when a more suitable alternative now exists.
+- Emphasize projects that are still worth learning from or selecting today, rather than projects that merely appeared historically.
+- Do not include the same project in multiple categories.
+
+## Update Recommendations
+
+For future maintenance, use this order:
+
+1. Update [projects.json](../projects.json) first.
+2. Run `go run ./tools/generate_readme.go`.
+3. If there are large migrations or removals, update the [removal and migration log](removal-and-migration-log.md) as well.
+4. Keep [README_EN.md](../README_EN.md) aligned with the generated Chinese README.

--- a/docs/removal-and-migration-log.md
+++ b/docs/removal-and-migration-log.md
@@ -1,0 +1,87 @@
+# Removal and Migration Log
+
+[Chinese version](移除与迁移记录.md)
+
+This document records the most important repository migrations and removals made during this refactor so future maintainers can trace the decisions.
+
+## Migrated to New Repository Entries
+
+| Old entry | New entry | Notes |
+| --- | --- | --- |
+| `docker/docker` | `moby/moby` | The Docker engine upstream source now lives under Moby. |
+| `vmware/harbor` | `goharbor/harbor` | Harbor's official repository has moved. |
+| `coreos/clair` | `quay/clair` | Clair has moved to the Quay organization. |
+| `containous/traefik` | `traefik/traefik` | Traefik's official repository name was updated. |
+| `lonelycode/tyk` | `TykTechnologies/tyk` | Tyk moved to its official organization. |
+| `bitly/nsq` | `nsqio/nsq` | NSQ moved to its official repository. |
+| `youtube/vitess` | `vitessio/vitess` | Vitess changed its official organization. |
+| `ipfs/go-ipfs` | `ipfs/kubo` | Go IPFS was renamed to Kubo. |
+| `henrylee2cn/pholcus` | `andeya/pholcus` | Pholcus now uses this official repository entry. |
+| `astaxie/beego` | `beego/beego` | Current maintenance entry for Beego. |
+| `robfig/revel` | `revel/revel` | Current maintenance entry for Revel. |
+| `micro/micro` | `micro/go-micro` | Current source entry for the microservices framework. |
+| `drone/drone` | `harness/harness` | Drone has become part of the Harness ecosystem. |
+| `etsy/hound` | `hound-search/hound` | Hound moved to its official repository. |
+| `mattermost/platform` | `mattermost/mattermost` | Current main repository for Mattermost. |
+
+## Archived and Removed Directly
+
+The following projects were clearly archived at review time, so they are no longer included:
+
+- `coreos/rkt`
+- `shipyard/shipyard`
+- `zettio/weave`
+- `coreos/torus`
+- `sourcegraph/appdash`
+- `uber/tchannel`
+- `bosun-monitor/bosun`
+- `gravitational/satellite`
+- `ooyala/atlantis`
+- `youtube/doorman`
+- `nanopack/yoke`
+- `silenceper/dcmp`
+- `inconshreveable/ngrok`
+- `yahoo/gryffin`
+- `apex/apex`
+- `codeskyblue/gosuv`
+- `vzex/dog-tunnel`
+- `pinggg/pingd`
+- `gernest/utron`
+- `lunny/tango`
+
+## Long-Inactive or Overlapping Projects No Longer Recommended
+
+The following projects did not enter the refreshed catalog mainly because they are long-inactive, overlap heavily with more active projects, or are now difficult to recommend as first-choice options:
+
+- `huichen/wukong`
+- `codetainerapp/codetainer`
+- `andyxning/shortme`
+- `afex/hystrix-go`
+- `mehrdadrad/mylg`
+- `cyfdecyf/cow`
+- `huichen/mlf`
+- `Qihoo360/poseidon`
+- `idcos/osinstall`
+- `fagongzi/gateway`
+- `andot/hprose`
+- `Terry-Mao/bfs`
+- `TalkingData/owl`
+- `cloudinsight/cloudinsight-agent`
+- `rach/pome`
+- `open-falcon/of-release`
+- `mesos/cloudfoundry-mesos`
+- `laincloud/lain`
+- `weibocom/opendcp`
+- `hoisie/web`
+- `codegangsta/martini`
+- `goshawkdb/server`
+- `slicebit/qb`
+- `chasex/redis-go-cluster`
+- `siddontang/ledisdb`
+- `degdb/degdb`
+- `blackbeans/kiteq`
+
+## Notes
+
+- This refresh is not a simple star-count ranking. The catalog was rebuilt around whether a project is still worth recommending today.
+- A small number of still-usable but clearly slower-moving projects are not all listed here; they have naturally exited the main catalog in the refreshed version.

--- a/docs/分类与维护策略.md
+++ b/docs/分类与维护策略.md
@@ -1,5 +1,7 @@
 # 分类与维护策略
 
+[English version](category-and-maintenance-policy.md)
+
 ## 这次重构的目标
 
 旧版目录的问题主要有四个:
@@ -40,6 +42,7 @@
 
 后续维护建议按下面的顺序执行:
 
-1. 先更新 [projects.json](/Users/root1/project/golang-open-source-projects/projects.json)。
+1. 先更新 [projects.json](../projects.json)。
 2. 再运行 `go run ./tools/generate_readme.go`。
-3. 如果发生大规模迁移或剔除, 同步更新 [移除与迁移记录](/Users/root1/project/golang-open-source-projects/docs/移除与迁移记录.md)。
+3. 如果发生大规模迁移或剔除, 同步更新 [移除与迁移记录](移除与迁移记录.md)。
+4. 保持 [README_EN.md](../README_EN.md) 与生成后的中文 README 同步。

--- a/docs/移除与迁移记录.md
+++ b/docs/移除与迁移记录.md
@@ -1,5 +1,7 @@
 # 移除与迁移记录
 
+[English version](removal-and-migration-log.md)
+
 这份文档记录的是这次重构里最重要的仓库迁移和剔除动作, 方便后续维护时追溯。
 
 ## 迁移到新的仓库入口

--- a/projects.json
+++ b/projects.json
@@ -54,6 +54,11 @@
           "name": "Weaviate",
           "repo": "weaviate/weaviate",
           "desc": "Go 编写的向量数据库，可用于 RAG、检索和 Agent memory。"
+        },
+        {
+          "name": "Agenvoy",
+          "repo": "pardnchiu/Agenvoy",
+          "desc": "Go 编写的 Agent 平台，提供 Py/Js 工具接口、错误记忆与自动修正能力。"
         }
       ]
     },
@@ -257,6 +262,11 @@
           "name": "rtop",
           "repo": "rapidloop/rtop",
           "desc": "基于 SSH 的轻量级远程服务器监控工具。"
+        },
+        {
+          "name": "KubeStellar Console",
+          "repo": "kubestellar/console",
+          "desc": "AI 驱动的多集群 Kubernetes 仪表盘，支持实时可观测性和 30+ CNCF 项目集成。CNCF Sandbox 项目。"
         }
       ]
     },

--- a/tools/generate_readme.go
+++ b/tools/generate_readme.go
@@ -52,6 +52,7 @@ func main() {
 	b.WriteString(data.Description)
 	b.WriteString("\n\n")
 	b.WriteString(fmt.Sprintf("当前版本收录 **%d** 个项目，分成 **%d** 个主题；最近一次维护状态审阅时间为 **%s**。\n\n", total, len(data.Categories), data.UpdatedAt))
+	b.WriteString("- [English version](README_EN.md)\n")
 	b.WriteString("- [分类与维护策略](docs/分类与维护策略.md)\n")
 	b.WriteString("- [移除与迁移记录](docs/移除与迁移记录.md)\n\n")
 


### PR DESCRIPTION
## Summary

- Add an English README that mirrors the refreshed Go open source project catalog.
- Add English versions of the category policy and removal/migration documentation.
- Link Chinese and English documentation in both directions.
- Sync the two latest README-only project additions back into `projects.json` so generated counts stay correct.

## Why

English readers did not have a maintained entry point for the catalog. The upstream README also included two project additions that had not been reflected in the JSON data source, so regenerating the README would have dropped them.

## Impact

- English-speaking readers can navigate the catalog and maintenance notes directly.
- Future README generation preserves `Agenvoy` and `KubeStellar Console` and reports 77 projects.
- The Chinese README now links to the English version.

## Validation

- `go run ./tools/generate_readme.go`
- `gofmt -w tools/generate_readme.go`
- `jq '[.categories[].projects | length] | add' projects.json`
- `git diff --check`

## Base branch note

This repository does not currently have a `main` branch. Its GitHub default branch is `master`, so this draft PR targets `master`.
