### PR TITLE
新增 Casdoor 到网络与安全分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 面向中文读者重新整理的 Go 开源项目目录。新版目录不再追求“尽可能全”，而是优先保留仍在维护、社区认知清晰、适合学习和选型的项目，并补充了 AI Agent 相关项目。
 
-当前版本收录 **77** 个项目，分成 **10** 个主题；最近一次维护状态审阅时间为 **2026-03-06**。
+当前版本收录 **78** 个项目，分成 **10** 个主题；最近一次维护状态审阅时间为 **2026-03-06**。
 
 - [English version](README_EN.md)
 - [分类与维护策略](docs/分类与维护策略.md)
@@ -31,7 +31,7 @@
 | 服务治理与平台工程 | PaaS、服务治理、CI/CD、消息与异步任务 | 12 |
 | 数据存储与搜索 | 数据库、分布式存储、检索与数据访问生态 | 10 |
 | 可观测性 | 指标、图表、告警与运行状态检查 | 6 |
-| 网络与安全 | 网关、负载均衡、代理、流量调试与网络工具 | 6 |
+| 网络与安全 | 网关、负载均衡、代理、流量调试与网络工具 | 7 |
 | Web 开发与应用 | Web 框架、服务端组件与实时交互能力 | 11 |
 | 数据处理与机器学习 | ML、NLP、爬虫与数据处理 | 6 |
 | 开发者工具与基础库 | 开发效率、测试、终端 UI 和核心基础库 | 8 |
@@ -122,6 +122,7 @@ PaaS、服务治理、CI/CD、消息与异步任务
 
 | 项目 | 简介 |
 | --- | --- |
+| [casdoor/casdoor](https://github.com/casdoor/casdoor) | 带 Web UI 的统一身份认证与访问控制（IAM/SSO）服务，支持 OAuth 2.0、OIDC、SAML、CAS 和 LDAP。 |
 | [traefik/traefik](https://github.com/traefik/traefik) | 云原生场景里广泛使用的反向代理和负载均衡器。 |
 | [google/seesaw](https://github.com/google/seesaw) | Google 开源的 Linux 负载均衡系统。 |
 | [jpillora/go-tcp-proxy](https://github.com/jpillora/go-tcp-proxy) | 实现简单、非常适合学习 TCP 代理原理。 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,7 +2,7 @@
 
 A curated Go open source project catalog for English readers. This refreshed list no longer tries to be exhaustive; it prioritizes projects that are still maintained, have clear community recognition, and are useful for learning or technology selection, with additional coverage for AI Agent projects.
 
-Current version includes **77** projects across **10** topics; the latest maintenance status review was completed on **2026-03-06**.
+Current version includes **78** projects across **10** topics; the latest maintenance status review was completed on **2026-03-06**.
 
 - [Chinese version](README.md)
 - [Category and maintenance policy](docs/category-and-maintenance-policy.md)
@@ -31,7 +31,7 @@ Current version includes **77** projects across **10** topics; the latest mainte
 | Service Governance and Platform Engineering | PaaS, service governance, CI/CD, messaging, and async jobs | 12 |
 | Data Storage and Search | Databases, distributed storage, search, and data access ecosystems | 10 |
 | Observability | Metrics, dashboards, alerting, and runtime health checks | 6 |
-| Networking and Security | Gateways, load balancing, proxies, traffic debugging, and network tools | 6 |
+| Networking and Security | Gateways, load balancing, proxies, traffic debugging, and network tools | 7 |
 | Web Development and Applications | Web frameworks, server-side components, and realtime interaction | 11 |
 | Data Processing and Machine Learning | ML, NLP, crawlers, and data processing | 6 |
 | Developer Tools and Core Libraries | Developer productivity, testing, terminal UI, and core libraries | 8 |
@@ -122,6 +122,7 @@ Gateways, load balancing, proxies, traffic debugging, and network tools
 
 | Project | Description |
 | --- | --- |
+| [casdoor/casdoor](https://github.com/casdoor/casdoor) | An identity and access management (IAM) / single sign-on (SSO) service with a web UI, supporting OAuth 2.0, OIDC, SAML, CAS, and LDAP. |
 | [traefik/traefik](https://github.com/traefik/traefik) | A widely used cloud native reverse proxy and load balancer. |
 | [google/seesaw](https://github.com/google/seesaw) | Google's open source Linux load balancing system. |
 | [jpillora/go-tcp-proxy](https://github.com/jpillora/go-tcp-proxy) | A simple implementation that is especially useful for learning TCP proxy fundamentals. |

--- a/projects.json
+++ b/projects.json
@@ -276,6 +276,11 @@
       "summary": "网关、负载均衡、代理、流量调试与网络工具",
       "projects": [
         {
+          "name": "Casdoor",
+          "repo": "casdoor/casdoor",
+          "desc": "带 Web UI 的统一身份认证与访问控制（IAM/SSO）服务，支持 OAuth 2.0、OIDC、SAML、CAS 和 LDAP。"
+        },
+        {
           "name": "Traefik",
           "repo": "traefik/traefik",
           "desc": "云原生场景里广泛使用的反向代理和负载均衡器。"


### PR DESCRIPTION
在 **网络与安全** 分类下新增 [casdoor/casdoor](https://github.com/casdoor/casdoor)。

Casdoor 是用 Go 编写、Apache-2.0 协议的统一身份认证与访问控制（IAM/SSO）服务，自带 Web UI，支持 OAuth 2.0、OIDC、SAML 2.0、CAS、LDAP、SCIM、WebAuthn 和 TOTP/MFA，可以作为自建的统一登录网关。

对照收录原则：
- 仍在活跃维护：14k+ star，版本发布持续进行
- 非归档、无更好替代：Go 生态里同类自建 IdP 的主要选择
- 只在一个分类中收录

改动方式：修改 `projects.json` 后运行 `go run tools/generate_readme.go` 重新生成 `README.md`，并同步手工更新 `README_EN.md`（条目、项目总数 77 → 78、分类计数 6 → 7）。